### PR TITLE
Kalman convergence fix

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -75,15 +75,13 @@ kalman <- function(df, warn = TRUE) {
     # Replace NA values in latitude with Kalman Smoothed estimates
     temp_df$y <- imputeTS::na.kalman(df$y, model = "StructTS", smooth = TRUE)
   }, warning = function(w) {
-    print("Running warning protocol; Kalman smoothing failed to converge \n
-          using structural time series modeling. Reverting to auto ARIMA approach")
+    print("Running warning protocol; Kalman smoothing failed to converge using structural time series modeling. Reverting to auto ARIMA approach")
     # Replace NA values in longitude using auto.arima approach
     temp_df$x <- imputeTS::na.kalman(df$x, model = "auto.arima", smooth = TRUE)
     # Replace NA values in latitude using auto.arima approach
     temp_df$y <- imputeTS::na.kalman(df$y, model = "auto.arima", smooth = TRUE)
   }, error = function(e) {
-    print("Running error protocol; Kalman smoothing failed to converge \n
-          using structural time series modeling. Reverting to auto ARIMA approach")
+    print("Running error protocol; Kalman smoothing failed to converge using structural time series modeling. Reverting to auto ARIMA approach")
     # Replace NA values in longitude using auto.arima approach
     temp_df$x <- imputeTS::na.kalman(df$x, model = "auto.arima", smooth = TRUE)
     # Replace NA values in latitude using auto.arima approach

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -69,27 +69,9 @@ kalman <- function(df, warn = TRUE) {
   df$real <- !is.na(df$x)
 
   temp_df <- df
-  tryCatch ({
-    # Replace NA values in longitude with Kalman Smoothed estimates
-    temp_df$x <- imputeTS::na.kalman(df$x, model = "StructTS", smooth = TRUE)
-    # Replace NA values in latitude with Kalman Smoothed estimates
-    temp_df$y <- imputeTS::na.kalman(df$y, model = "StructTS", smooth = TRUE)
-  }, warning = function(w) {
-    print("Running warning protocol; Kalman smoothing failed to converge using structural time series modeling. Reverting to auto ARIMA approach")
-    # Replace NA values in longitude using auto.arima approach
-    temp_df$x <- imputeTS::na.kalman(df$x, model = "auto.arima", smooth = TRUE)
-    # Replace NA values in latitude using auto.arima approach
-    temp_df$y <- imputeTS::na.kalman(df$y, model = "auto.arima", smooth = TRUE)
-  }, error = function(e) {
-    print("Running error protocol; Kalman smoothing failed to converge using structural time series modeling. Reverting to auto ARIMA approach")
-    # Replace NA values in longitude using auto.arima approach
-    temp_df$x <- imputeTS::na.kalman(df$x, model = "auto.arima", smooth = TRUE)
-    # Replace NA values in latitude using auto.arima approach
-    temp_df$y <- imputeTS::na.kalman(df$y, model = "auto.arima", smooth = TRUE)
-  }, finally = {
-    df$x <- temp_df$x
-    df_y <- temp_df$y
-  })
+  # Replace NA values in longitude and latitude with Kalman Smoothed estimates
+  temp_df$x <- imputeTS::na.kalman(df$x, model = "StructTS", smooth = TRUE)
+  temp_df$y <- imputeTS::na.kalman(df$y, model = "StructTS", smooth = TRUE)
   
   if (warn == TRUE) {
     if (sum(!df$real) / nrow(df) > .05) {
@@ -98,7 +80,15 @@ kalman <- function(df, warn = TRUE) {
         "% of values along your trajectory. We advise interpolating less than 5 %."
       ), call. = FALSE)
     }
+  
+    print("Running warning protocol; Kalman smoothing failed to converge using structural time series modeling. Reverting to auto ARIMA approach")
+    # Replace NA values in longitude and latitude using auto.arima approach
+    temp_df$x <- imputeTS::na.kalman(df$x, model = "auto.arima", smooth = TRUE)
+    temp_df$y <- imputeTS::na.kalman(df$y, model = "auto.arima", smooth = TRUE)
   }
+  
+  df$x <- temp_df$x
+  df$y <- temp_df$y
 
   return(df)
 }


### PR DESCRIPTION
Added tryCatch loop to Kalman so that auto.arima model is called if structTS spits failure to converge message. Not sure if it will fail to reach your error messaging regarding the 5% rule based on the tryCatch interruption. May want to add that into the error messaging.